### PR TITLE
always unwrap ex

### DIFF
--- a/src/qbits/auspex.clj
+++ b/src/qbits/auspex.clj
@@ -4,9 +4,8 @@
   code/ideas from the awesome manifold library."
   (:refer-clojure :exclude [future future? realized? loop recur])
   (:require [qbits.auspex :as a]
-            [qbits.auspex.executor :as executor]
             [qbits.auspex.function :as f]
-            qbits.auspex.impl
+            [qbits.auspex.impl :as impl]
             [qbits.auspex.protocols :as p])
   (:import (java.util.concurrent CompletableFuture)))
 
@@ -185,3 +184,5 @@
                 `(chain ~f (fn [~x] ~step))))
             `(do ~@body)
             (reverse steps-pairs))))
+
+(def ex-unwrap impl/ex-unwrap)

--- a/src/qbits/auspex.clj
+++ b/src/qbits/auspex.clj
@@ -186,3 +186,13 @@
             (reverse steps-pairs))))
 
 (def ex-unwrap impl/ex-unwrap)
+
+(defn unwrap
+  "Tries to deref a Future, returns a value upon completion or the
+  original exception that triggered exceptional termination (as
+  opposed to a wrapped exception)"
+  [f]
+  (try
+    @f
+    (catch Exception e
+      (throw (ex-unwrap e)))))

--- a/src/qbits/auspex.clj
+++ b/src/qbits/auspex.clj
@@ -185,7 +185,10 @@
             `(do ~@body)
             (reverse steps-pairs))))
 
-(def ex-unwrap impl/ex-unwrap)
+(def ex-unwrap
+  "Takes input exception and return the original exception cause (if
+  any). This unwraps `ExecutionException` and `CompletionException`"
+  impl/ex-unwrap)
 
 (defn unwrap
   "Tries to deref a Future, returns a value upon completion or the

--- a/src/qbits/auspex/impl.clj
+++ b/src/qbits/auspex/impl.clj
@@ -9,7 +9,6 @@
 
 (set! *warn-on-reflection* true)
 
-
 (defn relevant-ex
   [ex]
   (cond-> ex
@@ -46,7 +45,8 @@
 
   (-finally
     ([cf f]
-     (p/-finally cf f (executor/current-thread-executor)))
+     (p/-when-complete cf
+                       (fn [_ _] (f)))
     ([cf f executor]
      (p/-when-complete cf
                        (fn [_ _] (f))

--- a/test/qbits/auspex_test.clj
+++ b/test/qbits/auspex_test.clj
@@ -73,6 +73,11 @@
                @(doto (a/future)
                   (a/error! ex))))
 
+  (is (thrown? ExceptionInfo
+               (a/unwrap
+                (doto (a/future)
+                  (a/error! ex)))))
+
   (is (a/error? (doto (a/future)
                   (a/error! ex))))
 
@@ -85,7 +90,7 @@
          @(-> (doto (a/future)
                 (a/error! ex))
               (a/catch ExceptionInfo
-                       (fn [_] ::foo)))))
+                  (fn [_] ::foo)))))
 
   (is (thrown? ExecutionException
                @(-> (a/future (fn [] (throw (Exception. "meh")))
@@ -321,5 +326,3 @@
                        y (+ x 1)
                        z (a/future (fn [] (inc y)))]
                       [x y z]))))
-
-#_(run-tests)


### PR DESCRIPTION
* `catch` will now always unwrap the orignal exception (it was only doing it for arity-2 before). 
* adds `ex-unwrap` to do the same on ex instance manually if needed and `unwrap` that derefs and unwraps potential exceptions (since when you deref now CF will just return the wrapped exception).
