### PR TITLE
introduce `all` and `all'` to avoid `apply zip`. 

### DIFF
--- a/test/qbits/auspex_test.clj
+++ b/test/qbits/auspex_test.clj
@@ -326,3 +326,14 @@
                        y (+ x 1)
                        z (a/future (fn [] (inc y)))]
                       [x y z]))))
+
+(defn future-val
+  [x]
+  (a/future (constantly x)))
+
+(deftest all-any-test
+  (are [pred result f input] (pred result (deref (f input)))
+    =         [1 2 3]  a/all  [1 2 3]
+    =         [1 2 3]  a/all' (map future-val [1 2 3])
+    contains? #{1 2 3} a/any  [1 2 3]
+    contains? #{1 2 3} a/any' (map future-val [1 2 3])))


### PR DESCRIPTION
When dealing with functions which return collections of futures,
it can be cumbersome to resort to `apply zip` to generate a
deferred of the completion of all results.

Instead of a zip inspired name, this patch proposes using
terminology that is closer to CompletableFuture with `all-of`.